### PR TITLE
Fix bug passing statusCode to event handler

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,7 +35,7 @@ def handle_event(event:, context:)
     else
       return respond 400, 'Bad method'
     end
-    respond response['statusCode'], response
+    respond response[:statusCode], response
 
   rescue ParameterError => e
     respond 400, message: "ParameterError: #{e.message}"

--- a/lib/sierra_patron.rb
+++ b/lib/sierra_patron.rb
@@ -68,12 +68,18 @@ class SierraPatron < SierraModel
 
     response = self.sierra_client.get path
 
-    count = response.success? ? 1 : 0
-    {
-      data: response.body,
-      count: count,
-      statusCode: response.code
-    }
+    if response.success?
+      {
+        data: response.body,
+        count: 1,
+        statusCode: response.code
+      }
+    else
+      {
+        message: "Failed to retrieve #{path} from Sierra",
+        statusCode: response.code
+      }
+    end
   end
 
   def self.validate(barcode, pin)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -37,4 +37,85 @@ describe :app, :type => :controller do
       expect(parse_body({ 'body' => '{ "key1": "value2" }', 'bodyIsBase64Encoded' => true })).to include({ "key1" => "value2" })
     end
   end
+
+  describe :handle_event do
+    before(:each) do
+      KmsClient.aws_kms_client.stub_responses(:decrypt, -> (context) {
+        # "Decrypt" by subbing "encrypted" with "decrypted" in string:
+        { plaintext: context.params[:ciphertext_blob].gsub('encrypted', 'decrypted') }
+      })
+
+      stub_request(:post, "#{ENV['SIERRA_OAUTH_URL']}").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
+
+    end
+
+    it 'responds to /docs/patron with 200 and swagger doc' do
+      response = handle_event(
+        event: {
+          "path" => '/docs/patron',
+          "httpMethod" => 'GET'
+        },
+        context: {}
+      )
+
+      expect(response[:statusCode]).to eq(200)
+      expect(response[:body]).to be_a(String)
+      expect(JSON.parse(response[:body])).to be_a(Hash)
+      expect(JSON.parse(response[:body])['paths']).to be_a(Hash)
+    end
+
+    it 'responds to patrons/12345 with 200 and patron body' do
+      stub_request(:get, "#{ENV['SIERRA_API_BASE_URL']}patrons/12345")
+        .with(query: { "fields" => SierraPatron::PATRON_FIELDS })
+        .to_return({
+          status: 200,
+          body: File.read('./spec/fixtures/patron-12345.json'),
+          headers: { 'Content-Type' => 'application/json;charset=UTF-8' }
+        })
+
+      response = handle_event(
+        event: {
+          "path" => '/api/v0.1/patrons/12345',
+          "httpMethod" => 'GET',
+          "pathParameters" => { "id" => '12345' }
+        },
+        context: {}
+      )
+
+      expect(response[:statusCode]).to eq(200)
+      expect(response[:body]).to be_a(String)
+      expect(JSON.parse(response[:body])).to be_a(Hash)
+      expect(JSON.parse(response[:body])['data']).to be_a(Hash)
+      expect(JSON.parse(response[:body])['data']['id']).to eq(12345)
+    end
+
+    it 'passes Sierra status code to response' do
+      stub_request(:get, "#{ENV['SIERRA_API_BASE_URL']}patrons/5678")
+        .with(query: { "fields" => SierraPatron::PATRON_FIELDS })
+        .to_return({
+          status: 418,
+          body: {
+            "code" => 107,
+            "specificCode" => 0,
+            "httpStatus" => 418,
+            "name" => "I am a teapot"
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json;charset=UTF-8' }
+        })
+
+      response = handle_event(
+        event: {
+          "path" => '/api/v0.1/patrons/5678',
+          "httpMethod" => 'GET',
+          "pathParameters" => { "id" => '5678' }
+        },
+        context: {}
+      )
+
+      expect(response[:statusCode]).to eq(418)
+      expect(response[:body]).to be_a(String)
+      expect(JSON.parse(response[:body])).to be_a(Hash)
+      expect(JSON.parse(response[:body])['message']).to start_with("Failed to retrieve")
+    end
+  end
 end

--- a/spec/sierra_patron_spec.rb
+++ b/spec/sierra_patron_spec.rb
@@ -56,8 +56,8 @@ describe SierraPatron do
       resp = SierraPatron.by_id 56789
 
       expect(resp[:statusCode]).to eq(404)
-      expect(resp[:data]).to be_a(Hash)
-      expect(resp[:data]['httpStatus']).to eq(404)
+      expect(resp[:data]).to be_nil
+      expect(resp[:message]).to start_with("Failed to retrieve")
     end
 
     it "passes through malformed responses from Sierra" do


### PR DESCRIPTION
Fix bug where statusCode established for the response is not passed
correctly to lambda handler in some cases. (Turns out my unit testing
was not, on its own, sufficient..) Improves handling of 404
responses from Sierra. Improves coverage of `app.rb#handle_event` to
ensure the lambda callback produces the expected return.