### PR TITLE
Fix response for by_filter when handling 404

### DIFF
--- a/lib/sierra_patron.rb
+++ b/lib/sierra_patron.rb
@@ -48,12 +48,18 @@ class SierraPatron < SierraModel
 
       response = self.sierra_client.get path
 
-      count = response.success? ? 1 : 0
-      {
-        data: [ response.body ],
-        count: count,
-        statusCode: response.code
-      }
+      if response.success?
+        {
+          data: [ response.body ],
+          count: 1,
+          statusCode: response.code
+        }
+      else
+        {
+          message: "Failed to retrieve patron record by #{filter_name}=#{filters[filter_name]}",
+          statusCode: response.code
+        }
+      end
     end
   end
 

--- a/spec/sierra_patron_spec.rb
+++ b/spec/sierra_patron_spec.rb
@@ -114,6 +114,27 @@ describe SierraPatron do
       expect(resp[:data][0]['id']).to eq(12345)
     end
 
+    it "calls Sierra patrons/find endpoint, returns error response when Sierra responds with 404" do
+      stub_request(:get, "#{ENV['SIERRA_API_BASE_URL']}patrons/find")
+        .with(query: {
+          "fields" => SierraPatron::PATRON_FIELDS,
+          "varFieldContent" => "user@example.com",
+          "varFieldTag" => "z"
+         })
+        .to_return({
+          status: 404,
+          body: File.read('./spec/fixtures/patron-56789-missing.json'),
+          headers: { 'Content-Type' => 'application/json;charset=UTF-8' }
+        })
+
+      resp = SierraPatron.by_filters({ 'email' => 'user@example.com' })
+
+      expect(resp[:statusCode]).to eq(404)
+      expect(resp[:count]).to be_nil
+      expect(resp[:data]).to be_nil
+      expect(resp[:message]).to eq('Failed to retrieve patron record by email=user@example.com')
+    end
+
     it "calls Sierra patrons/find endpoint when querying by id" do
       stub_request(:get, "#{ENV['SIERRA_API_BASE_URL']}patrons/find")
         .with(query: {


### PR DESCRIPTION
Fixes how the patrons endpoint handles a 404 response from Sierra when
doing a patrons/find query (i.e. a query by barcode/url). This change
ensures that the endpoint matches the legacy PatronService response by
omitting the `data` property and serving an error `message`.