### PR TITLE
Add 'barCodes' alias to match legacy capitalization

### DIFF
--- a/spec/sierra_patron_spec.rb
+++ b/spec/sierra_patron_spec.rb
@@ -25,6 +25,11 @@ describe SierraPatron do
       expect(resp[:statusCode]).to eq(200)
       expect(resp[:data]).to be_a(Hash)
       expect(resp[:data]['id']).to eq(12345)
+      expect(resp[:data]['barcodes']).to be_a(Array)
+      expect(resp[:data]['barcodes']).to include('12345678901234')
+      # Must include legacy alias for barcodes:
+      expect(resp[:data]['barCodes']).to be_a(Array)
+      expect(resp[:data]['barCodes']).to include('12345678901234')
     end
 
     it "handles deleted patron records" do
@@ -90,6 +95,9 @@ describe SierraPatron do
       expect(resp[:data]).to be_a(Array)
       expect(resp[:data][0]).to be_a(Hash)
       expect(resp[:data][0]['id']).to eq(1000001)
+      expect(resp[:data][0]['barcodes']).to be_a(Array)
+      # Must include legacy alias for barcodes:
+      expect(resp[:data][0]['barCodes']).to be_a(Array)
     end
 
     it "calls Sierra patrons/find endpoint, returns array of records" do
@@ -112,6 +120,10 @@ describe SierraPatron do
       expect(resp[:data]).to be_a(Array)
       expect(resp[:data][0]).to be_a(Hash)
       expect(resp[:data][0]['id']).to eq(12345)
+      expect(resp[:data][0]['barcodes']).to be_a(Array)
+      expect(resp[:data][0]['barcodes']).to include('12345678901234')
+      expect(resp[:data][0]['barCodes']).to be_a(Array)
+      expect(resp[:data][0]['barCodes']).to include('12345678901234')
     end
 
     it "calls Sierra patrons/find endpoint, returns error response when Sierra responds with 404" do

--- a/swagger.json
+++ b/swagger.json
@@ -233,6 +233,12 @@
             "type": "string"
           }
         },
+        "barcodes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "expirationDate": {
           "type": "string",
           "example": "2017-08-20"

--- a/swagger.json
+++ b/swagger.json
@@ -227,14 +227,15 @@
             "type": "string"
           }
         },
-        "barCodes": {
+        "barcodes": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "barcodes": {
+        "barCodes": {
           "type": "array",
+          "description": "Alias for barcodes. Deprecated.",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
Legacy PatronService capitalized barcodes as "barCodes". Two known
downstream apps depend on that capitalization:

nypl-hold-request-consumer:
 - https://github.com/NYPL/nypl-hold-request-consumer/blob/1c5d95cb3c672ecfc8e9d20c5c8b1512920fa39c/src/helpers/ApiServiceHelper.js#L270
 - https://github.com/NYPL/nypl-hold-request-consumer/blob/1c5d95cb3c672ecfc8e9d20c5c8b1512920fa39c/src/helpers/SCSBApiHelper.js#L270

hold-request-result-consumer:
 - https://github.com/NYPL/hold-request-result-consumer/blob/4a54be26e5fcb4bcd4308abe334293ca338820ee/src/Model/DataModel/Patron.php#L57

This change adds 'barCodes' as an alias to 'barcodes' in all patron
record responses. (Known consumers appear to ignore extra properties
in the response.)