### PR TITLE
Fix some missing data transformations

### DIFF
--- a/spec/fixtures/patron-12345.json
+++ b/spec/fixtures/patron-12345.json
@@ -42,6 +42,22 @@
     ],
     "moneyOwed": 10.00,
     "fixedFields": {
+      "43": {
+        "label": "Expiration Date",
+        "value": "2022-06-23T08:00:00Z"
+      },
+      "96": {
+        "label": "Money Owed",
+        "value": "1275.000000"
+      },
+      "123": {
+        "label": "Debit Balance",
+        "value": "0.000000"
+      },
+      "124": {
+        "label": "Current Item C",
+        "value": "0"
+      }
     },
     "varFields": [
     ]


### PR DESCRIPTION
This adds some light data transformations discovered late in the legacy
PatronService:
 - Cast two specific fixedFields to integers (dropping decimal precision). Unclear why this was done, but SCSB depends on these two fields being cast to ints.
 - Format two datetimes with hour+minute timezone offset. Unclear if this is necessary, but it's a slight discrepancy with legacy behavior, so I want to close that gap. 