### PR TITLE
Add CORS header to allow use in platformdocs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -106,7 +106,8 @@ def respond(statusCode = 200, body = nil)
     statusCode: statusCode,
     body: body.to_json,
     headers: {
-      "Content-type": "application/json"
+      "Content-type": "application/json",
+      "Access-Control-Allow-Origin": "*"
     }
   }
 end


### PR DESCRIPTION
Add CORS header to allow cross-origin requests (e.g. platformdocs)